### PR TITLE
Migrate from @cliqz/adblocker to @cliqz/adblocker-puppeteer

### DIFF
--- a/lib/setup-beacon-recording.js
+++ b/lib/setup-beacon-recording.js
@@ -13,30 +13,41 @@ const url = require('url');
 const path = require('path');
 const logger = require('./logger');
 
-const { FiltersEngine, NetworkFilter, makeRequest } = require('@cliqz/adblocker');
-const { parse } = require('tldts');
+const { PuppeteerBlocker, fromPuppeteerDetails } = require('@cliqz/adblocker-puppeteer');
+
+// The following options make sure that blocker will behave optimally for the
+// use-case of identifying blocked network requests as well as the rule which
+// triggered blocking in the first place.
+const blockerOptions = {
+  // This makes sure that the instance of `PuppeteerBlocker` keeps track of the
+  // exact original rule form (from easylist or easyprivacy). Otherwise some
+  // information might be lost and calling `toString(...)` will only give back
+  // an approximate version.
+  debug: true,
+
+  // By default, instance of `PuppeteerBlocker` will perform some dynamic
+  // optimizations on rules to increase speed. As a result, it might not always
+  // be possible to get back the original rule which triggered a 'match' for
+  // a specific request. Disabling these optimizations will always ensure we
+  // can know which rule triggered blocking.
+  enableOptimizations: false,
+
+  // We are only interested in "network rules" to identify requests which would
+  // be blocked. Disabling "cosmetic rules" allows to resources.
+  loadCosmeticFilters: false,
+};
 
 // setup easyprivacy matching
 // https://github.com/cliqz-oss/adblocker/issues/123
-let filtersEngines = {
-  'easyprivacy.txt': FiltersEngine.parse(fs.readFileSync(path.join(__dirname, '../assets/easyprivacy.txt'), 'utf8'), {loadCosmeticFilters: false}),
-  'fanboy-annoyance.txt': FiltersEngine.parse(fs.readFileSync(path.join(__dirname, '../assets/fanboy-annoyance.txt'), 'utf8'), {loadCosmeticFilters: false}),
-};
-
-const typesMapping = {
-  document: 'main_frame',
-  eventsource: 'other',
-  fetch: 'xhr',
-  font: 'font',
-  image: 'image',
-  manifest: 'other',
-  media: 'media',
-  other: 'other',
-  script: 'script',
-  stylesheet: 'stylesheet',
-  texttrack: 'other',
-  websocket: 'websocket',
-  xhr: 'xhr',
+let blockers = {
+  'easyprivacy.txt': PuppeteerBlocker.parse(
+    fs.readFileSync(path.join(__dirname, '../assets/easyprivacy.txt'), 'utf8'),
+    blockerOptions,
+  ),
+  'fanboy-annoyance.txt': PuppeteerBlocker.parse(
+    fs.readFileSync(path.join(__dirname, '../assets/fanboy-annoyance.txt'), 'utf8'),
+    blockerOptions,
+  ),
 };
 
 // source: https://gist.github.com/pirate/9298155edda679510723#gistcomment-2734349
@@ -62,17 +73,12 @@ module.exports.setup_beacon_recording = async function(page) {
   // prepare easyprivacy list matching
   // requires to call somewhere: await page.setRequestInterception(true);
   page.on('request', (request) => {
-    Object.entries(filtersEngines).forEach(([listName, filtersEngine]) => {
+    Object.entries(blockers).forEach(([listName, blocker]) => {
       const {
         match,     // `true` if there is a match
-        redirect,  // data url to redirect to if any
-        exception, // instance of NetworkFilter exception if any
         filter,    // instance of NetworkFilter which matched
-      } = filtersEngine.match(makeRequest({
-        sourceUrl: request.frame().url(),
-        type: typesMapping[request.resourceType()],
-        url: request.url(),
-      }, parse));
+      } = blocker.match(fromPuppeteerDetails(request));
+
       if(match) {
         let stack = [{
           fileName: request.frame().url(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,29 @@
   "requires": true,
   "dependencies": {
     "@cliqz/adblocker": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-0.9.1.tgz",
-      "integrity": "sha512-D/2Rw8NW8Rn3Ts2UGHNJ8IzkOCHUbB/Jbi1v19pDgh4ox5SPf2qzxHIMH6603qRAzIkpM3xHw1BZRo3dr/itEQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker/-/adblocker-1.2.0.tgz",
+      "integrity": "sha512-Z+bfGX74nt1KYqK5Lj1a2wBQdtXarPyMMQRsMoW99795o7wp5yuqqiknXf0fmD/Ddqrd0qJktRXumBrJb9MckQ==",
       "requires": {
-        "tslib": "^1.9.3"
+        "tldts-experimental": "^5.3.0",
+        "tslib": "^1.10.0",
+        "tsmaz": "^1.3.0"
+      }
+    },
+    "@cliqz/adblocker-content": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-content/-/adblocker-content-1.2.0.tgz",
+      "integrity": "sha512-I4qHbry+/TN63TxWFGMuccJ7WFOVT1XTDN1sdLK1qU4dloa/87gS05PcwNUjdoboh/nwYgB/lrzqdo8zKmGtNg=="
+    },
+    "@cliqz/adblocker-puppeteer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@cliqz/adblocker-puppeteer/-/adblocker-puppeteer-1.2.0.tgz",
+      "integrity": "sha512-on2BHJ3sSNfqikyt7OccTtU8GUFzdaTv2rUIVGu7AH3gIO11LrpMAhHhsuWnogCsVqyievJokC+/ovVxptbyIw==",
+      "requires": {
+        "@cliqz/adblocker": "^1.2.0",
+        "@cliqz/adblocker-content": "^1.2.0",
+        "@types/puppeteer": "^1.12.4",
+        "tldts-experimental": "^5.3.0"
       }
     },
     "@hapi/bourne": {
@@ -17,6 +35,19 @@
       "resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-1.3.2.tgz",
       "integrity": "sha512-1dVNHT76Uu5N3eJNTYcvxee+jzX4Z9lfciqRRHCU27ihbUcYi+iSc2iml5Ke1LXe1SyJCLA0+14Jh4tXJgOppA==",
       "dev": true
+    },
+    "@types/node": {
+      "version": "12.7.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.9.tgz",
+      "integrity": "sha512-P57oKTJ/vYivL2BCfxCC5tQjlS8qW31pbOL6qt99Yrjm95YdHgNZwjrTTjMBh+C2/y6PXIX4oz253+jUzxKKfQ=="
+    },
+    "@types/puppeteer": {
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-1.20.0.tgz",
+      "integrity": "sha512-V3nWu/ENNW7LzHumrgf1D+HnIEQHE+nHThq9MTPmGjQC75SVlWsalCp1OaZFaDeuUgWOmQPIBhSLz0cz+Hlz8w==",
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "agent-base": {
       "version": "4.3.0",
@@ -1011,10 +1042,18 @@
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
     },
-    "tldts": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-4.0.6.tgz",
-      "integrity": "sha512-Or/FylLxfHc/vXMN0XTrY3MDlGqyeUIB1AYTN2QV2fnKJ3ZEpM4iTTofv8AdA09UbZtsPmvcSk841kpDqbM6bg=="
+    "tldts-core": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-5.5.0.tgz",
+      "integrity": "sha512-o0JzahqioihXz8wj7/1OYtefyhXz/PwLno7VRm5MTwQitEOPpvMPZpj2yjXtjgOMKbi3A5OHvvJwhFf0Hutzng=="
+    },
+    "tldts-experimental": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/tldts-experimental/-/tldts-experimental-5.5.0.tgz",
+      "integrity": "sha512-WU4DtSg4mPSjfXToGo6z9Wd681mEuv72bZNGX9HgLF2eaIAghAcGbjICK6L/rsUNjNHJMfh8prKW0bD6ZGawuA==",
+      "requires": {
+        "tldts-core": "^5.5.0"
+      }
     },
     "tmp": {
       "version": "0.1.0",
@@ -1040,9 +1079,14 @@
       "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
     },
     "tslib": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+    },
+    "tsmaz": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tsmaz/-/tsmaz-1.3.0.tgz",
+      "integrity": "sha512-vcU8dokp/QecvbTldQIE9Y4MD+ObU8VOpkwKCvhwhLv+yVdLMyjq7vTuc/haLLclRFRtMRj2z+qR7IjN+fnpiQ=="
     },
     "typedarray": {
       "version": "0.0.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://edps.europa.eu/press-publications/edps-inspection-software_en",
   "main": "website-evidence-collector",
   "dependencies": {
-    "@cliqz/adblocker": "^0.9.1",
+    "@cliqz/adblocker-puppeteer": "^1.2.0",
     "fs-extra": "^8.0.1",
     "git-describe": "^4.0.4",
     "js-yaml": "^3.13.1",
@@ -13,7 +13,6 @@
     "puppeteer": "^1.18.1",
     "puppeteer-har": "github:rriemann/puppeteer-har#1f8d9041e2d651e5be8bb7ed08f14b2e51cce875",
     "stacktrace-js": "^2.0.0",
-    "tldts": "^4.0.6",
     "tmp": "^0.1.0",
     "tough-cookie": "^3.0.1",
     "winston": "^3.2.1",


### PR DESCRIPTION
As a follow-up to #1 I'd like to propose the following changes to the project to simplify the usage of `@cliqz/adblocker`.

Migrate from [@cliqz/adblocker](https://www.npmjs.com/package/@cliqz/adblocker) to [@cliqz/adblocker-puppeteer](https://www.npmjs.com/package/@cliqz/adblocker-puppeteer):

* simplifies handling of puppeteer Request objects
* fine-tune options when creating engine instances
* remove non-needed tldts dependency