### PR TITLE
added support for cookies, similar to curl -b

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -71,9 +71,22 @@ The website evidence collector has been tested to work with TestSSL.sh in versio
 
 #### How do I gather evidence with given consent?
 
-If a particular website stores given user consent in a cookie and the encoding of consent in the cookie value is known, than the software can preset such a cookie. The website receives this consent cookie and would assumes from the very beginning of the browsing session that consent has been obtained.
+If a particular website stores given user consent in a cookie and the encoding of consent in the cookie value is known, than the software can pre-install such a consent cookie. The website receives this consent cookie and would assume from the beginning of the browsing session that consent has been obtained.
 
-TODO: example of such a cookie and example of a command line call.
+The website https://edps.europa.eu/ (as of March 2020) encodes given consent in a cookie named `edp_cookie_agree` with value `1` and for rejected consent with value `0`. The following examples demonstrate the configuration for the website evidence collector:
+
+    website-evidence-collector --set-cookie "edp_cookie_agree=1" http://edps.europa.eu
+    website-evidence-collector --set-cookie "edp_cookie_agree=0" http://edps.europa.eu
+
+The configuration is compatible with the cookie option (`--cookie` or `-b`) of the command line tool `curl` (cf. curl [manual page](https://curl.haxx.se/docs/manpage.html#-b)). Hence, the configuration allows to pre-install multiple cookies at the same time and to read cookies from local files.
+
+    website-evidence-collector --set-cookie "edp_cookie_agree=1;foo=bar" http://edps.europa.eu
+    website-evidence-collector --set-cookie "cookiejar.txt" http://edps.europa.eu
+
+**More Resources:**
+
+- <https://curl.haxx.se/docs/manpage.html#-b>
+- <https://curl.haxx.se/docs/http-cookies.html>
 
 ## Evaluation of the Output
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -69,6 +69,12 @@ The website evidence collector provides two options to embed the TestSSL.sh resu
 
 The website evidence collector has been tested to work with TestSSL.sh in version 3.0rc5.
 
+#### How do I gather evidence with given consent?
+
+If a particular website stores given user consent in a cookie and the encoding of consent in the cookie value is known, than the software can preset such a cookie. The website receives this consent cookie and would assumes from the very beginning of the browsing session that consent has been obtained.
+
+TODO: example of such a cookie and example of a command line call.
+
 ## Evaluation of the Output
 
 #### Which applications do you recommend to open and display the output?

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Please find a collection of frequently asked questions with answers in [FAQ.md](
 ## Contributors
 
 - Robert Riemann (European Data Protection Supervisor, initial author)
+- Company BitnessWise <https://www.bitnesswise.com/> (code to preset cookies)
 
 ## License
 

--- a/lib/argv.js
+++ b/lib/argv.js
@@ -37,6 +37,10 @@ var argv = require('yargs') // TODO use rather option('o', hash) syntax and defi
   .describe('l', 'Adds URI to list of links for browsing')
   .array('l')
 
+  // this argument behaves the same as curl -b
+  .alias('b', 'cookie')
+  .describe('b', '<name=string/file> Cookie string or file to read cookies from')
+
   .describe('headless', 'Hides the browser window')
   .boolean('headless')
   .default('headless', true)

--- a/lib/argv.js
+++ b/lib/argv.js
@@ -38,8 +38,8 @@ var argv = require('yargs') // TODO use rather option('o', hash) syntax and defi
   .array('l')
 
   // this argument behaves the same as curl -b
-  .alias('b', 'cookie')
-  .describe('b', '<name=string/file> Cookie string or file to read cookies from')
+  .alias('c', 'set-cookie')
+  .describe('c', '<name=string/file> Cookie string or file to read cookies from')
 
   .describe('headless', 'Hides the browser window')
   .boolean('headless')

--- a/lib/set-cookies.js
+++ b/lib/set-cookies.js
@@ -10,6 +10,9 @@ const fs = require('fs');
 const logger = require('./logger');
 const argv = require('./argv');
 
+// default cookie expiration time, this should result in a session-cookie
+const sessionCookieExpirationTime = -1;
+
 module.exports.set_cookies = async function(page, uri_ins) {
   // check if cookies need to be added
   if (argv.setCookie) {
@@ -58,7 +61,7 @@ module.exports.set_cookies = async function(page, uri_ins) {
           // add to the buffer
           cookieJar.push({
             value: cookieArr[6],
-            expires: cookieArr[4] == "0" ? cookieDefaultExpirationTime : cookieArr[4],
+            expires: cookieArr[4] == "0" ? sessionCookieExpirationTime : cookieArr[4],
             url: protocol+'://'+cookieArr[0]+cookieArr[2],
             name: cookieArr[5]
           });
@@ -76,7 +79,7 @@ module.exports.set_cookies = async function(page, uri_ins) {
           let cookieName = cookieStr.split(/=(.+)/)[0], cookieValue = cookieStr.split(/=(.+)/)[1];
           cookieJar.push({
             value: cookieValue,
-            expires: cookieDefaultExpirationTime,
+            expires: sessionCookieExpirationTime,
             url: uri_ins,
             name: cookieName
           });
@@ -88,12 +91,17 @@ module.exports.set_cookies = async function(page, uri_ins) {
 
     for (var c in cookieJar) {
       var cookie = cookieJar[c];
-      logger.log('info', `presetting cookie: ${cookie.name}=${cookie.value} for request ${cookie.url} with expiration ${cookie.expires}`);
+      if(cookie.expires >= 0) {
+        logger.log('info', `presetting persistant cookie ${cookie.name}=${cookie.value} for url ${cookie.url} with expiration in ${cookie.expires} ms`);
+      } else {
+        logger.log('info', `presetting session cookie ${cookie.name}=${cookie.value} for url ${cookie.url}`);
+      }
+      // https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagesetcookiecookies
       await page.setCookie({
+        "name": cookie.name,
         "value": cookie.value,
-        "expires": cookie.expires,
         "url": cookie.url,
-        "name": cookie.name
+        "expires": cookie.expires,
       });
     }
   }

--- a/lib/set-cookies.js
+++ b/lib/set-cookies.js
@@ -1,7 +1,6 @@
 /**
  * @file Set predefined cookies in the browser before browsing starts
- * @author BitnessWise <https://www.bitnesswise.com/>
- * @copyright European Data Protection Supervisor (2019)
+ * @author BitnessWise <https://www.bitnesswise.com/> and European Data Protection Supervisor
  * @license EUPL-1.2
  */
 

--- a/lib/set-cookies.js
+++ b/lib/set-cookies.js
@@ -1,0 +1,99 @@
+/**
+ * @file Set predefined cookies in the browser before browsing starts
+ * @author BitnessWise <https://www.bitnesswise.com/>
+ * @copyright European Data Protection Supervisor (2019)
+ * @license EUPL-1.2
+ */
+
+// jshint esversion: 8
+
+const fs = require('fs');
+const logger = require('./logger');
+const argv = require('./argv');
+
+module.exports.set_cookies = async function(page, uri_ins) {
+  // check if cookies need to be added
+  if (argv.setCookie) {
+    // variable that will buffer all the valid cookies that are passed
+    let cookieJar = [];
+    if (fs.existsSync(argv.setCookie)) {
+      // passed argument is the location of a file
+      logger.log('info', `read cookie parameter from the existing file: ${argv.setCookie}`);
+      let requestedDomain, protocol;
+      // TODO: isn't uri_ins always starting with http?
+      if (uri_ins.startsWith('http')) {
+        requestedDomain = uri_ins.split('/')[2];
+        protocol = uri_ins.split(':')[0];
+      }
+      else {
+        requestedDomain = uri_ins.split('/')[0];
+        protocol = "http";
+      }
+      // cookiefile should be small, so reading it into memory
+      const lines = fs.readFileSync(argv.setCookie, 'UTF-8').trim().split(/\r?\n/);
+      for(let line of lines) {
+        if (line.trim().indexOf('#') == 0) {
+          // this line is a comment; not parsing it
+          continue;
+        }
+        let cookieArr = line.split('\t');
+        if (cookieArr.length == 7) {
+          if (cookieArr[0] != requestedDomain || (protocol == "http" && cookieArr[3])) {
+            logger.info('info', `${line} doesn't match the requested domain or http url when cookie is https-only`);
+            continue;
+          }
+
+          // valid line, adding cookie
+          /***
+           * Netscape cookie file format, equal to how curl uses it:
+           *
+           * 0 | string  | example.com | Domain name
+           * 1 | boolean | FALSE       | Include subdomains
+           * 2 | string  | /foobar/    | Path
+           * 3 | boolean | TRUE        | Send/receive over HTTPS only
+           * 4 | number  | 1462299217  | Expires at – seconds since Jan 1st 1970, or -1
+           * 5 | string  | person      | Name of the cookie
+           * 6 | string  | daniel      | Value of the cookie
+           */
+
+          // add to the buffer
+          cookieJar.push({
+            value: cookieArr[6],
+            expires: cookieArr[4] == "0" ? cookieDefaultExpirationTime : cookieArr[4],
+            url: protocol+'://'+cookieArr[0]+cookieArr[2],
+            name: cookieArr[5]
+          });
+        }
+        else {
+          logger.log('error', 'invalid formatted line - skipping it : '+line);
+        }
+      }
+    }
+    else {
+      logger.log('info', 'cookie parameter is not an existing file; parsing it as key=value pairs');
+      let jarArr = argv.setCookie.split(";");
+      for (let cookieStr of jarArr) {
+        if (cookieStr.indexOf("=") >= 0) {
+          let cookieName = cookieStr.split(/=(.+)/)[0], cookieValue = cookieStr.split(/=(.+)/)[1];
+          cookieJar.push({
+            value: cookieValue,
+            expires: cookieDefaultExpirationTime,
+            url: uri_ins,
+            name: cookieName
+          });
+        }
+      }
+    }
+    // adding cookies from the buffer if we have them
+    for (var c in cookieJar) {
+      var cookie = cookieJar[c];
+      logger.log('info', `presetting cookie: ${cookie.name}=${cookie.value} for request ${cookie.url} with expiration ${cookie.expires}`);
+      await page.setCookie({
+        "value": cookie.value,
+        "expires": cookie.expires,
+        "url": cookie.url,
+        "name": cookie.name
+      });
+    }
+  }
+};

--- a/lib/set-cookies.js
+++ b/lib/set-cookies.js
@@ -85,6 +85,8 @@ module.exports.set_cookies = async function(page, uri_ins) {
       }
     }
     // adding cookies from the buffer if we have them
+    output.browser.preset_cookies = cookieJar;
+
     for (var c in cookieJar) {
       var cookie = cookieJar[c];
       logger.log('info', `presetting cookie: ${cookie.name}=${cookie.value} for request ${cookie.url} with expiration ${cookie.expires}`);

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -38,9 +38,6 @@ const { isFirstParty, getLocalStorage } = require('./lib/tools');
 const uri_ins = argv._[0];
 const uri_ins_host = url.parse(uri_ins).hostname; // hostname does not include port unlike host
 
-// default cookie expiration time, this should result in a session-cookie
-const cookieDefaultExpirationTime = -1;
-
 var uri_refs = [uri_ins].concat(argv.firstPartyUri);
 
 let uri_refs_stripped = uri_refs.map((uri_ref) => {

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -68,6 +68,7 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
   const { setup_cookie_recording } = require('./lib/setup-cookie-recording');
   const { setup_beacon_recording } = require('./lib/setup-beacon-recording');
   const { setup_websocket_recording } = require('./lib/setup-websocket-recording');
+  const { set_cookies } = require('./lib/set-cookies');
 
   const browser = await puppeteer.launch({
     headless: argv.headless,
@@ -109,6 +110,7 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
         version: os.release(),
       },
       extra_headers: {},
+      preset_cookies: {},
     },
     start_time: new Date(),
     end_time: null,
@@ -184,92 +186,13 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
     }
   });
 
+  // set predefined cookies if any
+  set_cookies(page, uri_ins);
+
   const har = new PuppeteerHar(page);
   await har.start({ path: argv.output ? path.join(argv.output, 'requests.har') : undefined });
 
   logger.log('info', `browsing now to ${uri_ins}`, {type: 'Browser'});
-
-  // check if cookies need to be added
-  if (argv.setCookie) {
-    // variable that will buffer all the valid cookies that are passed
-    let cookieJar = [];
-    if (fs.existsSync(argv.setCookie)) {
-      // passed argument is the location of a file
-      logger.log('info', 'cookie parameter is an existing file; reading values from '+argv.setCookie);
-      let requestedDomain, protocol;
-      if (uri_ins.indexOf('http') == 0) {
-        requestedDomain = uri_ins.split('/')[2];
-        protocol = uri_ins.split(':')[0];
-      }
-      else {
-        requestedDomain = uri_ins.split('/')[0];
-        protocol = "http";
-      }
-      // cookiefile should be small, so reading it into memory
-      const lines = fs.readFileSync(argv.setCookie, 'UTF-8').trim().split(/\r?\n/);
-      for(let line of lines) {
-        if (line.trim().indexOf('#') == 0) {
-          // this line is a comment; not parsing it
-          continue;
-        }
-        let cookieArr = line.split('\t');
-        if (cookieArr.length == 7) {
-          if (cookieArr[0] != requestedDomain || (protocol == "http" && cookieArr[3])) {
-            logger.info('info', line+' doesn\'t match the requested domain or http url when cookie is https-only');
-            continue;
-          }
-          // valid line, adding cookie
-          /***
-           * Netscape cookie file format, equal to how curl uses it: 
-           *
-           * 0 | string | example.com | Domain name
-           * 1 | boolean | FALSE | Include subdomains
-           * 2 | string | /foobar/ | Path
-           * 3 | boolean | TRUE | Send/receive over HTTPS only
-           * 4 | number | 1462299217 | Expires at – seconds since Jan 1st 1970, or 0
-           * 5 | string | person | Name of the cookie
-           * 6 | string | daniel | Value of the cookie
-           */
-          // add to the buffer
-          cookieJar.push({
-            value: cookieArr[6],
-            expires: cookieArr[4] == "0" ? cookieDefaultExpirationTime : cookieArr[4],
-            url: protocol+'://'+cookieArr[0]+cookieArr[2],
-            name: cookieArr[5]
-          });
-        }
-        else {
-          logger.log('error', 'invalid formatted line - skipping it : '+line);
-        }
-      }
-    }
-    else {
-      logger.log('info', 'cookie parameter is not an existing file; parsing it as key=value pairs');
-      let jarArr = argv.setCookie.split(";");
-      for (let cookieStr of jarArr) {
-        if (cookieStr.indexOf("=") >= 0) {
-          let cookieName = cookieStr.split(/=(.+)/)[0], cookieValue = cookieStr.split(/=(.+)/)[1];
-          cookieJar.push({
-            value: cookieValue,
-            expires: cookieDefaultExpirationTime,
-            url: uri_ins,
-            name: cookieName
-          });
-        }
-      }
-    }
-    // adding cookies from the buffer if we have them
-    for (var c in cookieJar) {
-      var cookie = cookieJar[c];
-      logger.log('info', 'setting initial cookie : '+cookie.name+'='+cookie.value+' for request '+cookie.url+' with expiration '+cookie.expires);
-      await page.setCookie({
-        "value": cookie.value,
-        "expires": cookie.expires,
-        "url": cookie.url,
-        "name": cookie.name
-      });
-    }
-  }
 
   let page_response;
   try {

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -187,7 +187,7 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
   });
 
   // set predefined cookies if any
-  set_cookies(page, uri_ins);
+  set_cookies(page, uri_ins, output);
 
   const har = new PuppeteerHar(page);
   await har.start({ path: argv.output ? path.join(argv.output, 'requests.har') : undefined });

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -38,6 +38,10 @@ const { isFirstParty, getLocalStorage } = require('./lib/tools');
 const uri_ins = argv._[0];
 const uri_ins_host = url.parse(uri_ins).hostname; // hostname does not include port unlike host
 
+// default the cookie expiration time, set to 5 minutes into the future.
+// This is a workaround because it seems session cookies (with expiration 0) are not sent
+const cookieDefaultExpirationTime = Math.floor(Date.now() / 1000) + 300
+
 var uri_refs = [uri_ins].concat(argv.firstPartyUri);
 
 let uri_refs_stripped = uri_refs.map((uri_ref) => {
@@ -185,6 +189,89 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
   await har.start({ path: argv.output ? path.join(argv.output, 'requests.har') : undefined });
 
   logger.log('info', `browsing now to ${uri_ins}`, {type: 'Browser'});
+
+  // check if cookies need to be added
+  if (argv.cookie) {
+    // variable that will buffer all the valid cookies that are passed
+    let cookieJar = [];
+    if (fs.existsSync(argv.cookie)) {
+      // passed argument is the location of a file
+      logger.log('info', 'cookie parameter is an existing file; reading values from '+argv.cookie);
+      let requestedDomain, protocol;
+      if (uri_ins.indexOf('http') == 0) {
+        requestedDomain = uri_ins.split('/')[2];
+        protocol = uri_ins.split(':')[0];
+      }
+      else {
+        requestedDomain = uri_ins.split('/')[0];
+        protocol = "http";
+      }
+      // cookiefile should be small, so reading it into memory
+      const lines = fs.readFileSync(argv.cookie, 'UTF-8').trim().split(/\r?\n/);
+      for(let line of lines) {
+        if (line.trim().indexOf('#') == 0) {
+          // this line is a comment; not parsing it
+          continue;
+        }
+        let cookieArr = line.split('\t');
+        if (cookieArr.length == 7) {
+          if (cookieArr[0] != requestedDomain || (protocol == "http" && cookieArr[3])) {
+            logger.info('info', line+' doesn\'t match the requested domain or http url when cookie is https-only');
+            continue;
+          }
+          // valid line, adding cookie
+          /***
+           * Netscape cookie file format, equal to how curl uses it: 
+           *
+           * 0 | string | example.com | Domain name
+           * 1 | boolean | FALSE | Include subdomains
+           * 2 | string | /foobar/ | Path
+           * 3 | boolean | TRUE | Send/receive over HTTPS only
+           * 4 | number | 1462299217 | Expires at – seconds since Jan 1st 1970, or 0
+           * 5 | string | person | Name of the cookie
+           * 6 | string | daniel | Value of the cookie
+           */
+          // add to the buffer
+          cookieJar.push({
+            value: cookieArr[6],
+            expires: cookieArr[4] == "0" ? cookieDefaultExpirationTime : cookieArr[4],
+            url: protocol+'://'+cookieArr[0]+cookieArr[2],
+            name: cookieArr[5]
+          });
+        }
+        else {
+          logger.log('error', 'invalid formatted line - skipping it : '+line);
+        }
+      }
+    }
+    else {
+      logger.log('info', 'cookie parameter is not an existing file; parsing it as key=value pairs');
+      let jarArr = argv.cookie.split(";");
+      for (let cookieStr of jarArr) {
+        if (cookieStr.indexOf("=") >= 0) {
+          let cookieName = cookieStr.split(/=(.+)/)[0], cookieValue = cookieStr.split(/=(.+)/)[1];
+          cookieJar.push({
+            value: cookieValue,
+            expires: cookieDefaultExpirationTime,
+            url: uri_ins,
+            name: cookieName
+          });
+        }
+      }
+    }
+    // adding cookies from the buffer if we have them
+    for (var c in cookieJar) {
+      var cookie = cookieJar[c];
+      logger.log('info', 'setting initial cookie : '+cookie.name+'='+cookie.value+' for request '+cookie.url+' with expiration '+cookie.expires);
+      await page.setCookie({
+        "value": cookie.value,
+        "expires": cookie.expires,
+        "url": cookie.url,
+        "name": cookie.name
+      });
+    }
+  }
+
   let page_response;
   try {
     page_response = await page.goto(uri_ins, {timeout: argv.pageTimeout, waitUntil : 'networkidle2' });

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -38,9 +38,8 @@ const { isFirstParty, getLocalStorage } = require('./lib/tools');
 const uri_ins = argv._[0];
 const uri_ins_host = url.parse(uri_ins).hostname; // hostname does not include port unlike host
 
-// default the cookie expiration time, set to 5 minutes into the future.
-// This is a workaround because it seems session cookies (with expiration 0) are not sent
-const cookieDefaultExpirationTime = Math.floor(Date.now() / 1000) + 300
+// default cookie expiration time, this should result in a session-cookie
+const cookieDefaultExpirationTime = -1;
 
 var uri_refs = [uri_ins].concat(argv.firstPartyUri);
 
@@ -191,12 +190,12 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
   logger.log('info', `browsing now to ${uri_ins}`, {type: 'Browser'});
 
   // check if cookies need to be added
-  if (argv.cookie) {
+  if (argv.setCookie) {
     // variable that will buffer all the valid cookies that are passed
     let cookieJar = [];
-    if (fs.existsSync(argv.cookie)) {
+    if (fs.existsSync(argv.setCookie)) {
       // passed argument is the location of a file
-      logger.log('info', 'cookie parameter is an existing file; reading values from '+argv.cookie);
+      logger.log('info', 'cookie parameter is an existing file; reading values from '+argv.setCookie);
       let requestedDomain, protocol;
       if (uri_ins.indexOf('http') == 0) {
         requestedDomain = uri_ins.split('/')[2];
@@ -207,7 +206,7 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
         protocol = "http";
       }
       // cookiefile should be small, so reading it into memory
-      const lines = fs.readFileSync(argv.cookie, 'UTF-8').trim().split(/\r?\n/);
+      const lines = fs.readFileSync(argv.setCookie, 'UTF-8').trim().split(/\r?\n/);
       for(let line of lines) {
         if (line.trim().indexOf('#') == 0) {
           // this line is a comment; not parsing it
@@ -246,7 +245,7 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
     }
     else {
       logger.log('info', 'cookie parameter is not an existing file; parsing it as key=value pairs');
-      let jarArr = argv.cookie.split(";");
+      let jarArr = argv.setCookie.split(";");
       for (let cookieStr of jarArr) {
         if (cookieStr.indexOf("=") >= 0) {
           let cookieName = cookieStr.split(/=(.+)/)[0], cookieValue = cookieStr.split(/=(.+)/)[1];


### PR DESCRIPTION
This adds a new argument by which cookies can be added to the initial request. It should work similar to how 'curl -b' works: you can either specify the cookies as key=value pairs (separated by a semicolon) or specify a file which contains cookies. This file should have the same format as the one curl -b expects