### PR TITLE
Pass user-data-dir via parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * feature: respect environment variables such as `WEC_MAX=10` or `WEC_headless=false`
 * feature: introduce option `--browser-options <browser options>` as an alternative to the `-- <browser options>` syntax (required for Docker setup)
 * bugfix: update yargs dependency to get bugfix https://github.com/yargs/yargs-parser/issues/261 for `--browser-options` starting with double dash `--`
+* feature: add commandline option `--browser-profile` (`-p`) to allow the reuse of existing browser profiles (thanks to Hamburg DPA staff!)
 
 ## 0.4.0 / 2020-01-17
 

--- a/lib/argv.js
+++ b/lib/argv.js
@@ -103,8 +103,8 @@ var argv = require('yargs') // TODO use rather option('o', hash) syntax and defi
   .array('browser-options')
   .default('browser-options', [])
 
-  .alias('p', 'browser-profile')
   .describe('browser-profile', 'Directory containing a custom browser profile')
+  .alias('p', 'browser-profile')
   .nargs('browser-profile', 1)
 
   .describe('testssl', 'call of testssl.sh executable and integrate its output')

--- a/lib/argv.js
+++ b/lib/argv.js
@@ -103,6 +103,10 @@ var argv = require('yargs') // TODO use rather option('o', hash) syntax and defi
   .array('browser-options')
   .default('browser-options', [])
 
+  .alias('p', 'browser-profile')
+  .describe('browser-profile', 'Directory containing a custom browser profile')
+  .nargs('browser-profile', 1)
+
   .describe('testssl', 'call of testssl.sh executable and integrate its output')
   .boolean('testssl')
   .conflicts('testssl', 'testssl-file')

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -77,7 +77,9 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
       width: WindowSize.width,
       height: WindowSize.height,
     },
-    userDataDir: argv.browserProfile ? argv.browserProfile : argv.output ? path.join(argv.output, 'browser-profile') : undefined,
+    userDataDir: argv.browserProfile ? argv.browserProfile :
+                   argv.output ? path.join(argv.output, 'browser-profile') :
+                     undefined,
     args: [
       `--user-agent=${UserAgent}`,
       `--window-size=${WindowSize.width},${WindowSize.height}`,

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -77,7 +77,7 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
       width: WindowSize.width,
       height: WindowSize.height,
     },
-    userDataDir: argv.output ? path.join(argv.output, 'browser-profile') : undefined,
+    userDataDir: argv.browserProfile ? argv.browserProfile : argv.output ? path.join(argv.output, 'browser-profile') : undefined,
     args: [
       `--user-agent=${UserAgent}`,
       `--window-size=${WindowSize.width},${WindowSize.height}`,


### PR DESCRIPTION
Hi,

I added the functionality to pass a custom user profile to WEC through command-line parameter. 

We often use WEC at the Hamburg Data Protection Commissioner to compare websites before and after accepting a cookie banner or other terms. It is way easier for us to simply spawn a chromium instance once on a clean profile, click all required buttons and then pass that whole profile to WEC than to try and manage the same thing with a cookies.txt file. 