### PR TITLE
Catching promise rejection on localStorage access

### DIFF
--- a/lib/tools.js
+++ b/lib/tools.js
@@ -9,6 +9,7 @@
 
 const url = require('url');
 const path = require ('path');
+const logger = require('./logger');
 
 safeJSONParse = function (obj) {
   try {
@@ -37,10 +38,17 @@ module.exports.getLocalStorage = async function(page, data = {}) {
     if(!frame.url().startsWith('http')) continue; // filters chrome-error://, about:blank and empty url
 
     const securityOrigin = new url.URL(frame.url()).origin;
-    const response = await client.send('DOMStorage.getDOMStorageItems',
-      { storageId: { isLocalStorage: true, securityOrigin } },
-    );
-    if (response.entries.length > 0) {
+    let response;
+    try {
+      response = await client.send('DOMStorage.getDOMStorageItems',
+        { storageId: { isLocalStorage: true, securityOrigin } }
+      );
+    } catch (error) {
+      // ignore error if no localStorage for given origin can be
+      // returned, see also: https://stackoverflow.com/q/62356783/1407622
+      logger.log('warn', error.message, {type: 'Browser'});
+    }
+    if (response && response.entries.length > 0) {
       let entries = {};
       for (const [key,val] of response.entries) {
         entries[key] = {

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -366,8 +366,13 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
       continue;
     }
 
+    try {
     await page.waitFor(argv.sleep); // in ms
     localStorage = await getLocalStorage(page, localStorage);
+    } catch (error) {
+      logger.log('warn', error.message, {type: 'Browser'});
+      continue;
+    }
   }
 
 

--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -366,13 +366,8 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
       continue;
     }
 
-    try {
     await page.waitFor(argv.sleep); // in ms
     localStorage = await getLocalStorage(page, localStorage);
-    } catch (error) {
-      logger.log('warn', error.message, {type: 'Browser'});
-      continue;
-    }
   }
 
 


### PR DESCRIPTION
On some sites the getLocalStorage promise rejects for me, stopping the whole collection process. Most of the times we're interested in 3rd-party ressources only, so LocalStorage isn't our immediate concern.
I added a simple logging catch block around the failing lines. Further error handling may be necessary to ensure proper functionality in situations where LocalStorage inspection is required. 

I don't really understand _why_ this happens, but I'm willing to help if you have any idea. 