### PR TITLE
Argument option '--html-template' fixed

### DIFF
--- a/website-evidence-collector.js
+++ b/website-evidence-collector.js
@@ -648,7 +648,7 @@ var refs_regexp = new RegExp(`^(${uri_refs_stripped.join('|')})\\b`, 'i');
   }
 
   if (argv.output || argv.html) {
-    let html_template = argv.html_template || path.join(__dirname, 'assets/template.pug');
+    let html_template = argv['html-template'] || path.join(__dirname, 'assets/template.pug');
     let html_dump = pug.renderFile(html_template, Object.assign({}, output, {
       pretty: true,
       basedir: __dirname,


### PR DESCRIPTION
Command line argument option '--html-template' was not working, at least when tested in Ubuntu 18. The reason was that while defined in ./lib/argv.js as 'html-template' it was used in ./website-evidence-collector.js as 'argv.html_template', so field names do not match. 'argv.html_template' replaced by 'argv['html-template']' in ./website-evidence-collector.js (line 651)