### PR TITLE
fix for #53

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # build from source code folder: docker build -t website-evidence-collector .
 # run container with e.g.:
 # docker run --rm -it --cap-add=SYS_ADMIN -v $(pwd)/output:/output \
-#   website-evidene-collector http://example.com/about
+#   website-evidence-collector http://example.com/about
 # If you hit the Error: EACCES: permission denied,
 # then try "mkdir output && chown 1000 output"
 

--- a/lib/set-cookies.js
+++ b/lib/set-cookies.js
@@ -20,7 +20,7 @@ module.exports.set_cookies = async function(page, uri_ins) {
     let cookieJar = [];
     if (fs.existsSync(argv.setCookie)) {
       // passed argument is the location of a file
-      logger.log('info', `read cookie parameter from the existing file: ${argv.setCookie}`);
+      logger.log('info', `Read cookie parameter from the existing file: ${argv.setCookie}`);
       let requestedDomain, protocol;
       // TODO: isn't uri_ins always starting with http?
       if (uri_ins.startsWith('http')) {
@@ -34,17 +34,22 @@ module.exports.set_cookies = async function(page, uri_ins) {
       // cookiefile should be small, so reading it into memory
       const lines = fs.readFileSync(argv.setCookie, 'UTF-8').trim().split(/\r?\n/);
       for(let line of lines) {
-        if (line.trim().indexOf('#') == 0) {
+        httpOnly = false;
+	if (line.trim().substring(0,10) == "#HttpOnly_") {
+	  // cookie that is flagged as http-only. stripping the flag so we can match the domain later on.
+	  line = line.trim().substring(10);
+          httpOnly = true;
+	}
+	else if (line.trim().indexOf('#') == 0) {
           // this line is a comment; not parsing it
           continue;
         }
+	else if (line.trim() == "") {
+	  // this is a blank line; ignoring it
+	  continue;
+	}
         let cookieArr = line.split('\t');
         if (cookieArr.length == 7) {
-          if (cookieArr[0] != requestedDomain || (protocol == "http" && cookieArr[3])) {
-            logger.info('info', `${line} doesn't match the requested domain or http url when cookie is https-only`);
-            continue;
-          }
-
           // valid line, adding cookie
           /***
            * Netscape cookie file format, equal to how curl uses it:
@@ -59,11 +64,13 @@ module.exports.set_cookies = async function(page, uri_ins) {
            */
 
           // add to the buffer
-          cookieJar.push({
+          cookieJar.push({              
+            name: cookieArr[5],
             value: cookieArr[6],
-            expires: cookieArr[4] == "0" ? sessionCookieExpirationTime : cookieArr[4],
-            url: protocol+'://'+cookieArr[0]+cookieArr[2],
-            name: cookieArr[5]
+            expires: cookieArr[4] == "0" ? sessionCookieExpirationTime : parseInt(cookieArr[4]),
+            domain: cookieArr[0],
+            path: cookieArr[2],
+            secure: cookieArr[3].toLowerCase() == "true" ? true : false
           });
         }
         else {
@@ -87,22 +94,13 @@ module.exports.set_cookies = async function(page, uri_ins) {
       }
     }
     // adding cookies from the buffer if we have them
-    output.browser.preset_cookies = cookieJar;
-
-    for (var c in cookieJar) {
-      var cookie = cookieJar[c];
-      if(cookie.expires >= 0) {
-        logger.log('info', `presetting persistant cookie ${cookie.name}=${cookie.value} for url ${cookie.url} with expiration in ${cookie.expires} ms`);
-      } else {
-        logger.log('info', `presetting session cookie ${cookie.name}=${cookie.value} for url ${cookie.url}`);
+    if (cookieJar.length > 0) {
+      for (var c in cookieJar) {
+        logger.log('info', 'adding '+(cookieJar[c].expires >= 0 ? 'persistant' : 'session')+' cookie '+cookieJar[c].name);
       }
+      output.browser.preset_cookies = cookieJar;
       // https://pptr.dev/#?product=Puppeteer&version=v2.1.1&show=api-pagesetcookiecookies
-      await page.setCookie({
-        "name": cookie.name,
-        "value": cookie.value,
-        "url": cookie.url,
-        "expires": cookie.expires,
-      });
+      await page.setCookie(...cookieJar);
     }
   }
 };


### PR DESCRIPTION
https://github.com/EU-EDPS/website-evidence-collector/issues/53 bumped into two problems: a blank line in the source file resulted in an error being reported (misformatted line) - but that is just cosmetics. However the other problem is that a dot-cookie on the main domain wasn't used for subdomains

Apart from that I noticed another deviation : the way httponly flags are logged. And I found a problem where expiry times were not converted from string to int.

Also removed code that tried to match the domain and instead it's now relying on puppeteer correctly applying it by setting the domain name for the cookie.

This is all fixed in the pull request