### PR TITLE
Two small fixes

### DIFF
--- a/lib/setup-beacon-recording.js
+++ b/lib/setup-beacon-recording.js
@@ -67,7 +67,7 @@ const decodeURLParams = search => {
 
 
     try {
-    return Object.assign(params, { [key]: decodeURIComponent(val) });
+      return Object.assign(params, { [key]: decodeURIComponent(val) });
     } catch {
       return Object.assign(params, { [key]: val });
     }

--- a/lib/setup-beacon-recording.js
+++ b/lib/setup-beacon-recording.js
@@ -86,8 +86,8 @@ module.exports.setup_beacon_recording = async function(page) {
 
       if(match) {
         let stack = [{
-          fileName: request.frame().url(),
-          source: `requested from ${request.frame().url()} and matched with ${listName} filter ${filter}`,
+          fileName: request.url(),
+          source: `requested from ${request.url()} and matched with ${listName} filter ${filter}`,
         }];
         const parsedUrl = url.parse(request.url());
         let query = null;

--- a/lib/setup-beacon-recording.js
+++ b/lib/setup-beacon-recording.js
@@ -65,7 +65,12 @@ const decodeURLParams = search => {
     const key = hash.slice(0, split);
     const val = hash.slice(split + 1);
 
+
+    try {
     return Object.assign(params, { [key]: decodeURIComponent(val) });
+    } catch {
+      return Object.assign(params, { [key]: val });
+    }
   }, {});
 };
 


### PR DESCRIPTION
Two fixes for two respective crashes I encountered in a recent case. One was an unhandled error and the other a missing null-check that could be bypassed by using `request.url()` instead of `request.frame().url()`.

I couldn't find out if there's an actual difference between `request.url()` and `request.frame().url()` but the [documentation](https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#httprequestframe) explicitly states that `request.frame()` is null for error pages, which seems to be what triggered the crashes in our case.

The other was URL parameters in the form `%%PARAMETER%%` that `decodeURIComponent()`apparently interprets as url-encoded but obviously cannot decode. 