### PR TITLE
fix crash when parsing illegal cookie strings

### DIFF
--- a/lib/setup-cookie-recording.js
+++ b/lib/setup-cookie-recording.js
@@ -129,16 +129,16 @@ module.exports.setup_cookie_recording = async function(page) {
         fileName: req.url(),
         source: `set in Set-Cookie HTTP response header for ${req.url()}`,
       }];
-      let splitCookieHeaders = cookieHTTP.split("\n");
-      let data = splitCookieHeaders.map(cookieParser.parse);
-      data.forEach( (cookie) => {
-        if(!cookie.domain) {
-          // what is the domain if not set explicitly?
-          // https://stackoverflow.com/a/5258477/1407622
-          cookie.domain = new url.URL(response.url()).hostname;
-        }
-      });
-      let message = `${data.length} Cookie(s) (HTTP) set for host ${data[0].domain} with key(s) ${data.map(c => {return c.key;}).join(', ')}.`;
+      let domain = new url.URL(response.url()).hostname;
+      let data = cookieHTTP.split("\n")
+        .map(cookieParser.parse)
+        .filter(Boolean) //tough-cookie.Cookie.parse returns undefined for broken cookie strings
+        .map(cookie => {
+            // what is the domain if not set explicitly?
+            // https://stackoverflow.com/a/5258477/1407622
+            cookie.domain ||= domain;
+        });
+      let message = `${data.length} Cookie(s) (HTTP) set for host ${domain}${data.length ? " with key(s) " : ""}${data.map(c => {return c.key;}).join(', ')}.`;
 
       // find mainframe
       let frame = response.frame();


### PR DESCRIPTION
We have a project right now where the website in question sets this cookie header that always makes WEC crash:

![image](https://user-images.githubusercontent.com/365169/118523041-09309900-b73d-11eb-928e-0e5e2ca5e0a1.png)

This patch adds a filter to the cookie parsing routine that removes ```undefined``` entries returned by tough-cookie's ```parse()``` method for illegal cookie strings. 
