### PR TITLE
Spell out "days" in cookie report

### DIFF
--- a/assets/template.pug
+++ b/assets/template.pug
@@ -329,7 +329,7 @@ html(xmlns='http://www.w3.org/1999/xhtml', xml:lang='en', lang='en')
               th.notrunc Host
               th.notrunc Path
               th.trunc Name
-              th.notrunc Expiry in d
+              th.notrunc Expiry in days
           tbody
             each cookie,index in cookieList
               tr


### PR DESCRIPTION
Hello and thanks for working on this very important tool!

I don't know if this was intentional or a typo, but I don't think you can expect all users to understand that "d" is short for "days" here. Having it spelled out makes me more confident that people without prior experience with cookies can understand the data :)