### PR TITLE
Fix for broken cookie support

### DIFF
--- a/collector/browser-session.js
+++ b/collector/browser-session.js
@@ -136,7 +136,7 @@ async function createBrowserSession(browser_args, browser_logger) {
     });
 
     // set predefined cookies if any
-    set_cookies(page, output.uri_ins, output, logger);
+    set_cookies(page, output.uri_ins, args, output, logger);
 
     har = new PuppeteerHar(page);
 


### PR DESCRIPTION
Someone reached out to me because setting cookies wasn't working for him and after some investigation I found it is currently broken. This commit fixes that.
(Btw, even though I did a hard reset to sync with the upstream, for some reason it included a fix I did last year - not sure why. But although the commit is included, there is no code change involved, so should be harmless)