### PR TITLE
Prevent a crash when handling specific links (SVG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * fix: non-compliant cookie headers such as ` ; sameSite=None` with no key are discarded from the logging and matching
 * feature: add clickable anchors to all sections in the html output with AnchorJS
 * feature: add config object to output
+* fix: crash when websites employ links in SVGs (PR #91)
 
 ## 2.0.0 / 2022-06-30
 

--- a/collector/index.js
+++ b/collector/index.js
@@ -77,7 +77,7 @@ async function collector(args, logger) {
 
   c.collectLinks = async function () {
     // get all links from page
-    const links = await collector_inspect.collectLinks(c.pageSession.page);
+    const links = await collector_inspect.collectLinks(c.pageSession.page, c.logger);
 
     var mappedLinks = await collector_inspect.mapLinksToParties(
       links,

--- a/collector/inspector.js
+++ b/collector/inspector.js
@@ -14,7 +14,7 @@ const {
 
 async function collectLinks(page, logger) {
   // get all links from page
-  const links_with_duplicates = await page.evaluate(() => {
+  const links_all_with_duplicates = await page.evaluate(() => {
     return Array.from(document.querySelectorAll("a[href]"), (a) => {
         return {
           href: a.href.toString().split("#").shift(), // link without fragment
@@ -24,14 +24,16 @@ async function collectLinks(page, logger) {
     });
   });
   
-  const links = links_with_duplicates.filter((link) => {
+  const links_http_with_duplicates = links_all_with_duplicates.filter((link) => {
     if (link.href === '[object SVGAnimatedString]') {
       logger.log('warn', 'Unsupported SVG link detected and discarded', link);
     }
     return link.href.startsWith("http");
   });
+  
+  const links_http_without_duplicates = Array.from(new Set(links_http_with_duplicates));
 
-  return links;
+  return links_http_without_duplicates;
 }
 
 async function mapLinksToParties(links, hosts, refs_regexp) {

--- a/collector/inspector.js
+++ b/collector/inspector.js
@@ -18,8 +18,12 @@ async function collectLinks(page) {
   const links_with_duplicates = await page.evaluate(() => {
     return [].map
       .call(Array.from(document.querySelectorAll("a[href]")), (a) => {
+        const href = a.href.toString();
+        if (href === '[object SVGAnimatedString]') {
+          console.warn('[WebsiteEvidenceCollector] SVG links are not supported');
+        }
         return {
-          href: a.href.toString().split("#")[0], // link without fragment
+          href: href.split("#")[0], // link without fragment
           inner_text: a.innerText,
           inner_html: a.innerHTML.trim(),
         };

--- a/collector/inspector.js
+++ b/collector/inspector.js
@@ -1,6 +1,5 @@
 // jshint esversion: 8
 
-const uniqWith = require("lodash/uniqWith");
 const fs = require("fs-extra");
 const yaml = require("js-yaml");
 const path = require("path");
@@ -16,27 +15,20 @@ const {
 async function collectLinks(page, logger) {
   // get all links from page
   const links_with_duplicates = await page.evaluate(() => {
-    return [].map
-      .call(Array.from(document.querySelectorAll("a[href]")), (a) => {
-        const href = a.href.toString();
-        if (href === '[object SVGAnimatedString]') {
-          logger.log('warn', 'Unsupported SVG link detected and discarded', a);
-        }
+    return Array.from(document.querySelectorAll("a[href]"), (a) => {
         return {
-          href: href.split("#")[0], // link without fragment
+          href: a.href.toString().split("#").shift(), // link without fragment
           inner_text: a.innerText,
           inner_html: a.innerHTML.trim(),
-        };
-      })
-      .filter((link) => {
-        return link.href.startsWith("http");
-      });
+        }
+    });
   });
-
-  // https://lodash.com/docs/4.17.15#uniqWith
-  const links = uniqWith(links_with_duplicates, (l1, l2) => {
-    // consider URLs equal if only fragment (part after #) differs.
-    return l1.href.split("#").shift() === l2.href.split("#").shift();
+  
+  const links = links_with_duplicates.filter((link) => {
+    if (link.href === '[object SVGAnimatedString]') {
+      logger.log('warn', 'Unsupported SVG link detected and discarded', link);
+    }
+    return link.href.startsWith("http");
   });
 
   return links;

--- a/collector/inspector.js
+++ b/collector/inspector.js
@@ -13,14 +13,14 @@ const {
   safeJSONParse,
 } = require("../lib/tools");
 
-async function collectLinks(page) {
+async function collectLinks(page, logger) {
   // get all links from page
   const links_with_duplicates = await page.evaluate(() => {
     return [].map
       .call(Array.from(document.querySelectorAll("a[href]")), (a) => {
         const href = a.href.toString();
         if (href === '[object SVGAnimatedString]') {
-          console.warn('[WebsiteEvidenceCollector] SVG links are not supported');
+          logger.log('warn', 'Unsupported SVG link detected and discarded', a);
         }
         return {
           href: href.split("#")[0], // link without fragment

--- a/collector/inspector.js
+++ b/collector/inspector.js
@@ -19,7 +19,7 @@ async function collectLinks(page) {
     return [].map
       .call(Array.from(document.querySelectorAll("a[href]")), (a) => {
         return {
-          href: a.href.split("#")[0], // link without fragment
+          href: a.href.toString().split("#")[0], // link without fragment
           inner_text: a.innerText,
           inner_html: a.innerHTML.trim(),
         };


### PR DESCRIPTION
We are using your great tool to check some of our sites, and one of them generates an error. 
This website is using a SVG map with links where the href attribute is not a string, but a SVGAnimatedString object (which don't have a split method) 
My proposition is to simply apply a toString() on the href for now (It will give us a string "[object SVGAElement]", which will be filtered out just after because it does not start with "http") 
A better solution could be to fully manage this kind of link, retrieving the correct href if you prefer, but it may be complicated as this kind of object can have two values (baseVal and animVal)... 
Anyway, thanks for your work, we will probably send some PR as soon as we are ready !